### PR TITLE
Make `contourplot` plot `AbstractChains`

### DIFF
--- a/src/output/plot.jl
+++ b/src/output/plot.jl
@@ -130,7 +130,7 @@ function barplot(c::AbstractChains; legend::Bool=false,
   return plots
 end
 
-function contourplot(c::ModelChains; bins::Integer=100, na...)
+function contourplot(c::AbstractChains; bins::Integer=100, na...)
   nrows, nvars, nchains = size(c.value)
   plots = Plot[]
   offset = 1e4 * eps()


### PR DESCRIPTION
This PR make `contourplot` work on `AbstractChains` and not only on `ModelChains <: AbstractChains`.
